### PR TITLE
MODORG-51. Update mod-organization md required interface section

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -73,6 +73,14 @@
     {
       "id": "organizations-storage.organizations",
       "version": "3.3"
+    },
+    {
+      "id": "acquisitions-units-storage.units",
+      "version": "1.1"
+    },
+    {
+      "id": "acquisitions-units-storage.memberships",
+      "version": "1.0"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
Overview:

Update mod-organizations module descriptors required interface section,

add acquisitions-units-storage.units and acquisitions-units-storage.memberships into required interface section.

https://issues.folio.org/browse/MODORG-51