### PR TITLE
MODORG-64. Missing interface dependencies in module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -127,6 +127,10 @@
     {
       "id": "acquisitions-units-storage.memberships",
       "version": "1.0"
+    },
+    {
+      "id": "organizations-storage.banking-information",
+      "version": "1.0"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODORG-64