### PR TITLE
MODORG-75: Warning "checkOperationsRestrictions:: unitIds is empty"

### DIFF
--- a/src/main/java/org/folio/service/protection/ProtectionServiceImpl.java
+++ b/src/main/java/org/folio/service/protection/ProtectionServiceImpl.java
@@ -53,8 +53,13 @@ public class ProtectionServiceImpl implements ProtectionService {
   @Override
   public Future<Void> checkOperationsRestrictions(List<String> unitIds, Set<ProtectedOperationType> operations, Context context, Map<String, String> headers) {
     logger.debug("checkOperationsRestrictions:: Trying to check operation restrictions by unitIds: {} and '{}' operations", unitIds, operations.size());
-    if (CollectionUtils.isNotEmpty(unitIds)) {
-      return getUnitsByIds(unitIds, context, headers)
+
+    if (CollectionUtils.isEmpty(unitIds)) {
+      logger.debug("checkOperationsRestrictions:: unitIds is empty");
+      return Future.succeededFuture();
+    }
+
+    return getUnitsByIds(unitIds, context, headers)
         .compose(units -> {
           if (unitIds.size() == units.size()) {
             logger.info("checkOperationsRestrictions:: equal unitIds size '{}' and fetched units size '{}'", unitIds.size(), units.size());
@@ -70,10 +75,6 @@ public class ProtectionServiceImpl implements ProtectionService {
           }
           return Future.succeededFuture();
         });
-    } else {
-      logger.warn("checkOperationsRestrictions:: unitIds is empty");
-      return Future.succeededFuture();
-    }
   }
 
   @Override


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODORG-75

## Purpose
Access to the organization record can be restricted a list of AcqUnits so that a user must be member of at least one of these units to get access.

If an organization record is not restricted the list of AcqUnits is empty.

Actual:

mod-organization writes this WARN message into the mod-organization log:

```
checkOperationsRestrictions:: unitIds is empty
```

Expected:

That message should be a DEBUG message because unrestricted organizations are common.

## Approach
Change log level from WARN to DEBUG.

Convert the else branch of the if-else clause into a guard clause (separate if clause) for readability.

## Learning
Don't use WARN log level for states that are correct. WARN messages create work for sysops.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code are 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.